### PR TITLE
Use _cursor as annotation name to minimize clashes

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -91,11 +91,11 @@ class CursorPaginator(object):
         position = self.decode_cursor(cursor)
 
         is_reversed = self.ordering[0].startswith('-')
-        queryset = queryset.annotate(cursor=Tuple(*[o.lstrip('-') for o in self.ordering]))
+        queryset = queryset.annotate(_cursor=Tuple(*[o.lstrip('-') for o in self.ordering]))
         current_position = [Value(p, output_field=TextField()) for p in position]
         if reverse != is_reversed:
-            return queryset.filter(cursor__lt=Tuple(*current_position))
-        return queryset.filter(cursor__gt=Tuple(*current_position))
+            return queryset.filter(_cursor__lt=Tuple(*current_position))
+        return queryset.filter(_cursor__gt=Tuple(*current_position))
 
     def decode_cursor(self, cursor):
         try:


### PR DESCRIPTION
:wave:

I'm using this library with a model that defines a `cursor` field, which causes django to raise an exception as the annotation name is already in use.

I've prepended an underscore as that's less likely to clash, but it may be worth allowing the user to optionally pass in a name to use. Let me know if you think it's worth doing and I can fix this up.