### PR TITLE
On mysql, compare CONCAT'd values rather than tuple of values

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -14,6 +14,11 @@ class Tuple(Func):
     function = ''
     output_field = TupleField()
 
+    def as_mysql(self, compiler, connection):
+        self.function = 'CONCAT_WS'
+        self.template = "%(function)s('', %(expressions)s)"
+        return super(Tuple, self).as_sql(compiler, connection)
+
 
 class InvalidCursor(Exception):
     pass


### PR DESCRIPTION
When ordering by two or more fields as well as supplying a `cursor` argument to the `CurorPaginator.page` function, the ORM will generate a query something along the lines of this

```sql
SELECT `project`.`id`,
       `project`.`name`,
       `project`.`date_created`,
       (`project`.`date_created`, `project`.`id`) AS `_cursor`
FROM `project`
WHERE ((`project`.`date_created`, `project`.`id`) > (2017-02-16 17:41:42+00:00, 1739438))
ORDER BY `project`.`date_created` DESC,
         `project`.`id` DESC
```

On mysql this breaks at the `AS '_cursor'` part - `OperationalError: (1241, 'Operand should contain 1 column(s)')`.

It seems mysql doesn't allow you to select a tuple. To get around this, I'm concatenating the values instead.

With this change, the query generated looks more like this (`as_mysql` logic was taken from [here](https://github.com/django/django/blob/335aa088245a4cc6f1b04ba098458845344290bd/django/db/models/functions.py#L50-L54))

```sql
SELECT `project`.`id`,
       `project`.`name`,
       `project`.`date_created`,
       CONCAT_WS('', `project`.`date_created`, `project`.`id`) AS `_cursor`
FROM `project`
WHERE (CONCAT_WS('', `project`.`date_created`, `project`.`id`) < (CONCAT_WS('', 2017-02-16 17:41:42+00:00, 1739438)))
ORDER BY `project`.`date_created` DESC,
         `project`.`id` DESC
```

From my limited testing, this does seem to work (I'm using django 1.9.13), but I'm not 100% certain of the performance impact or potential comparison differences of using `concat` rather than comparing tuples.