### PR TITLE
Populate has_previous and has_next for forward and backwards

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,5 +64,10 @@ Caveats
 -------
 
 - The ordering specified **must** uniquely identify the object.
-- If there are multiple ordering fields, then they must all have the same direction
-- No support for multiple ordering fields in SQLite as it does not support tuple comparison.
+- If there are multiple ordering fields, then they must all have the same
+  direction
+- No support for multiple ordering fields in SQLite as it does not support
+  tuple comparison.
+- If a cursor is given and it does not refer to a valid object, the values of
+  `has_previous` (for `after`) or `has_next` (for `before`) will always return
+  `True`.

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -83,8 +83,10 @@ class CursorPaginator(object):
         additional_kwargs = {}
         if first is not None:
             additional_kwargs['has_next'] = has_additional
+            additional_kwargs['has_previous'] = bool(after)
         elif last is not None:
             additional_kwargs['has_previous'] = has_additional
+            additional_kwargs['has_next'] = bool(before)
         return CursorPage(items, self, **additional_kwargs)
 
     def apply_cursor(self, cursor, queryset, reverse=False):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -49,7 +49,7 @@ class TestForwardPagination(TestCase):
         page = self.paginator.page(first=2, after=cursor)
         self.assertSequenceEqual(page, [self.items[2], self.items[3]])
         self.assertTrue(page.has_next)
-        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_previous)
 
     def test_last_page(self):
         previous_page = self.paginator.page(first=18)
@@ -57,7 +57,7 @@ class TestForwardPagination(TestCase):
         page = self.paginator.page(first=2, after=cursor)
         self.assertSequenceEqual(page, [self.items[18], self.items[19]])
         self.assertFalse(page.has_next)
-        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_previous)
 
     def test_incomplete_last_page(self):
         previous_page = self.paginator.page(first=18)
@@ -65,7 +65,7 @@ class TestForwardPagination(TestCase):
         page = self.paginator.page(first=100, after=cursor)
         self.assertSequenceEqual(page, [self.items[18], self.items[19]])
         self.assertFalse(page.has_next)
-        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_previous)
 
 
 class TestBackwardsPagination(TestCase):
@@ -91,7 +91,7 @@ class TestBackwardsPagination(TestCase):
         page = self.paginator.page(last=2, before=cursor)
         self.assertSequenceEqual(page, [self.items[16], self.items[17]])
         self.assertTrue(page.has_previous)
-        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_next)
 
     def test_last_page(self):
         previous_page = self.paginator.page(last=18)
@@ -99,7 +99,7 @@ class TestBackwardsPagination(TestCase):
         page = self.paginator.page(last=2, before=cursor)
         self.assertSequenceEqual(page, [self.items[0], self.items[1]])
         self.assertFalse(page.has_previous)
-        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_next)
 
     def test_incomplete_last_page(self):
         previous_page = self.paginator.page(last=18)
@@ -107,7 +107,7 @@ class TestBackwardsPagination(TestCase):
         page = self.paginator.page(last=100, before=cursor)
         self.assertSequenceEqual(page, [self.items[0], self.items[1]])
         self.assertFalse(page.has_previous)
-        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_next)
 
 
 class TestTwoFieldPagination(TestCase):


### PR DESCRIPTION
This change populates the `has_previous` and `has_next` attributes of CursorPage. Inspired by DRF's CursorPagination.

It's not very smart as it assumes if `before` or `after` have been set it's not on the first or last page for forward and backward pagination respectively. Personally, I think this is enough.

I have updated tests and I don't think there is a need for any more as everything I changed was fairly well covered to begin with.