### PR TITLE
add a gitignore file with common python ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+build/
+dist/
+*.egg-info/
+*.pyc


### PR DESCRIPTION
This PR adds a `.gitignore` file to the root of the repo to ignore .pyc files and other common python build artifacts.