### PR TITLE
Remove SQLite caveat from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ Caveats
 
 - The ordering specified **must** uniquely identify the object.
 - If there are multiple ordering fields, then they must all have the same
-  direction
-- No support for multiple ordering fields in SQLite as it does not support
-  tuple comparison.
+  direction.
 - If a cursor is given and it does not refer to a valid object, the values of
   `has_previous` (for `after`) or `has_next` (for `before`) will always return
   `True`.


### PR DESCRIPTION
SQLite has supported tuple (row value) comparisons since version 3.15,
according to the SQLite documentation at https://sqlite.org/rowvalue.html