### PR TITLE
Django 3.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8]
-        django-version: [2.1, 2.2]
+        django-version: [2.2, 3.0, 3.1]
 
     services:
       postgres:

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -2,7 +2,6 @@ from base64 import b64decode, b64encode
 from collections import Sequence
 
 from django.db.models import Field, Func, Value, TextField
-from django.utils import six
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -130,7 +129,7 @@ class CursorPaginator(object):
             while parts:
                 attr = getattr(attr, parts[0])
                 parts.pop(0)
-            position.append(six.text_type(attr))
+            position.append(str(attr))
         return position
 
     def cursor(self, instance):

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )


### PR DESCRIPTION
- Test against newer versions of Django (2.2 and 3.0) and Python (3.8)
- Drop tests for Django 2.1 as it's EOL
- Drop tests for Python 2.7 and 3.4 as they're EOL
- Simplified Travis config