### PR TITLE
add support for .values() querysets

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -128,7 +128,7 @@ class CursorPaginator(object):
             parts = order.lstrip('-').split('__')
             attr = instance
             while parts:
-                attr = getattr(attr, parts[0])
+                attr = getattr(attr, parts[0]) if not isinstance(attr, dict) else attr[parts[0]]
                 parts.pop(0)
             position.append(six.text_type(attr))
         return position

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -168,3 +168,24 @@ class TestRelationships(TestCase):
         cursor = self.paginator.cursor(self.items[17])
         page = self.paginator.page(first=2, after=cursor)
         self.assertSequenceEqual(page, [self.items[19], self.items[0]])
+
+
+class TestRelationshipsValues(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.items = []
+        author_1 = Author.objects.create(name='Ana')
+        author_2 = Author.objects.create(name='Bob')
+        for i in range(20):
+            post = Post.objects.create(name='Name %02d' % i, author=author_1 if i % 2 else author_2)
+            cls.items.append(post)
+        cls.paginator = CursorPaginator(Post.objects.all().values('author__name', 'name'), ('author__name', 'name'))
+
+    def test_first_page(self):
+        page = self.paginator.page(first=2)
+        self.assertSequenceEqual(page, [self.items[1], self.items[3]])
+
+    def test_after_page(self):
+        cursor = self.paginator.cursor(self.items[17])
+        page = self.paginator.page(first=2, after=cursor)
+        self.assertSequenceEqual(page, [self.items[19], self.items[0]])


### PR DESCRIPTION
This PR aims to add support for querysets created with `.values(...)`.

In such case, `position_from_instance(self, instance)` recieve a `dict` instead of a ORM object, therefore failing at line 131 with AttributeError, since it tries to access the value using `getattr` instead of `get`

I extended the tests for that use-case, but I am not sure how to start them?