### PR TITLE
Replace gettext_lazy with ugettext_lazy

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -2,7 +2,7 @@ from base64 import b64decode, b64encode
 from collections import Sequence
 
 from django.db.models import Field, Func, Value, TextField
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class TupleField(Field):


### PR DESCRIPTION
RemovedInDjango40Warning: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy()