### PR TITLE
Fix deprecation warning re importing Sequence

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -1,5 +1,8 @@
 from base64 import b64decode, b64encode
-from collections import Sequence
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
 
 from django.db.models import Field, Func, Value, TextField
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
Currently, there is a waring regarding importing `Sequence` from `collecitons` instead of `collections.abc`:
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
    from collections import Sequence

Attempt to first import form `collections.abc` followed by `collections`.