### PR TITLE
Only import Sequence from collections.abc

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -1,8 +1,5 @@
 from base64 import b64decode, b64encode
-try:
-    from collections.abc import Sequence
-except ImportError:
-    from collections import Sequence
+from collections.abc import Sequence
 
 from django.db.models import Field, Func, Value, TextField
 from django.utils.translation import gettext_lazy as _


### PR DESCRIPTION
`collections.abc` has been available since Python 3.3. The fallback implemented here is only necessary for Python 2 or Python < 3.3. None of the supported Django versions run on Python 2 or Python 3.3, so this fallback is never required.