### PR TITLE
Implement NULL value ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,4 @@ Caveats
 - If a cursor is given and it does not refer to a valid object, the values of
   `has_previous` (for `after`) or `has_next` (for `before`) will always return
   `True`.
+- `NULL` comes at the end in query results with `ORDER BY` both for `ASC` and `DESC`.

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -46,18 +46,22 @@ class CursorPaginator(object):
         self.queryset = queryset.order_by(*self._nulls_ordering(ordering))
         self.ordering = ordering
 
-    def _nulls_ordering(self, ordering, last=False):
+    def _nulls_ordering(self, ordering, from_last=False):
+        """
+        This clarifies that NULL value comes at the end in the sort.
+        When "from_last" is specified, NULL value comes first since we return the results in reversed order.
+        """
         nulls_ordering = []
         for o in ordering:
             is_reversed = o.startswith('-')
             o = o.lstrip('-')
             if is_reversed:
-                if last:
+                if from_last:
                     nulls_ordering.append(F(o).desc(nulls_first=True))
                 else:
                     nulls_ordering.append(F(o).desc(nulls_last=True))
             else:
-                if last:
+                if from_last:
                     nulls_ordering.append(F(o).asc(nulls_first=True))
                 else:
                     nulls_ordering.append(F(o).asc(nulls_last=True))
@@ -72,16 +76,18 @@ class CursorPaginator(object):
         if page_size is None:
             return CursorPage(qs, self)
 
+        from_last = last is not None
+        if from_last and first is not None:
+            raise ValueError('Cannot process first and last') 
+
         if after is not None:
-            qs = self.apply_cursor(after, qs)
+            qs = self.apply_cursor(after, qs, from_last=from_last)
         if before is not None:
-            qs = self.apply_cursor(before, qs, reverse=True)
+            qs = self.apply_cursor(before, qs, from_last=from_last, reverse=True)
         if first is not None:
             qs = qs[:first + 1]
         if last is not None:
-            if first is not None:
-                raise ValueError('Cannot process first and last')
-            qs = qs.order_by(*self._nulls_ordering(reverse_ordering(self.ordering), last=True))[:last + 1]
+            qs = qs.order_by(*self._nulls_ordering(reverse_ordering(self.ordering), from_last=True))[:last + 1]
 
         qs = list(qs)
         items = qs[:page_size]
@@ -97,7 +103,7 @@ class CursorPaginator(object):
             additional_kwargs['has_next'] = bool(before)
         return CursorPage(items, self, **additional_kwargs)
 
-    def apply_cursor(self, cursor, queryset, reverse=False):
+    def apply_cursor(self, cursor, queryset, from_last, reverse=False):
         position = self.decode_cursor(cursor)
 
         # this was previously implemented as tuple comparison done on postgres side
@@ -116,19 +122,20 @@ class CursorPaginator(object):
         # `reverse` is False.
         # In order to apply cursor, we need to generate a following WHERE-clause:
 
-        # WHERE ((field1 < value1) OR
-        #     (field1 = value1 AND field2 > value2) OR
-        #     (field1 = value1 AND field2 = value2 AND field3 < value3).
+        # WHERE ((field1 < value1 OR field1 IS NULL) OR
+        #     (field1 = value1 AND (field2 > value2 OR field2 IS NULL)) OR
+        #     (field1 = value1 AND field2 = value2 AND (field3 < value3 IS NULL)).
         #
+        # Keep in mind, NULL is considered the last part of each field's order. 
         # We will use `__lt` lookup for `<`,
         # `__gt` for `>` and `__exact` for `=`.
         # (Using case-sensitive comparison as long as
         # cursor values come from the DB against which it is going to be compared).
         # The corresponding django ORM construct would look like:
         # filter(
-        #     Q(field1__lt=Value(value1)) |
-        #     Q(field1__exact=Value(value1), field2__gt=Value(value2)) |
-        #     Q(field1__exact=Value(value1), field2__exact=Value(value2), field3__lt=Value(value3))
+        #     Q(field1__lt=Value(value1) OR field1__isnull=True) |
+        #     Q(field1__exact=Value(value1), (Q(field2__gt=Value(value2) | Q(field2__isnull=True)) |
+        #     Q(field1__exact=Value(value1), field2__exact=Value(value2), (Q(field3__lt=Value(value3) | Q(field3__isnull=True)))
         # )
 
         # In order to remember which keys we need to compare for equality on the next iteration,
@@ -148,23 +155,24 @@ class CursorPaginator(object):
         for ordering, value in zip(self.ordering, position_values):
             is_reversed = ordering.startswith('-')
             o = ordering.lstrip('-')
-            if value is None:
+            if value is None:  # cursor value for the key was NULL
                 key = "{}__isnull".format(o)
-                if reverse is True:
+                if from_last is True:  # if from_last & cursor value is NULL, we need to get non Null for the key
                     q = {key : False}
                     q.update(q_equality)
                     filtering |= Q(**q)
 
                 q_equality.update({key: True})
-            else:
+            else:  # cursor value for the key was non NULL
                 if reverse != is_reversed:
                     comparison_key = "{}__lt".format(o)
                 else:
                     comparison_key = "{}__gt".format(o)
 
-                q = {comparison_key: value}
-                q.update(q_equality)
-                filtering |= Q(**q)
+                q = Q(**{comparison_key: value})
+                if not from_last:  # if not from_last, NULL values are still candidates
+                     q |= Q(**{"{}__isnull".format(o): True})
+                filtering |= (q) & Q(**q_equality)
 
                 equality_key = "{}__exact".format(o)
                 q_equality.update({equality_key: value})

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -52,19 +52,19 @@ class CursorPaginator(object):
         When "from_last" is specified, NULL value comes first since we return the results in reversed order.
         """
         nulls_ordering = []
-        for o in ordering:
-            is_reversed = o.startswith('-')
-            o = o.lstrip('-')
+        for key in ordering:
+            is_reversed = key.startswith('-')
+            column = key.lstrip('-')
             if is_reversed:
                 if from_last:
-                    nulls_ordering.append(F(o).desc(nulls_first=True))
+                    nulls_ordering.append(F(column).desc(nulls_first=True))
                 else:
-                    nulls_ordering.append(F(o).desc(nulls_last=True))
+                    nulls_ordering.append(F(column).desc(nulls_last=True))
             else:
                 if from_last:
-                    nulls_ordering.append(F(o).asc(nulls_first=True))
+                    nulls_ordering.append(F(column).asc(nulls_first=True))
                 else:
-                    nulls_ordering.append(F(o).asc(nulls_last=True))
+                    nulls_ordering.append(F(column).asc(nulls_last=True))
 
         return nulls_ordering
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 
 class Author(models.Model):
     name = models.CharField(max_length=20)
+    age = models.IntegerField(blank=True, null=True)
     created = models.DateTimeField(default=timezone.now)
 
     def __str__(self):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -28,82 +28,6 @@ class TestNoArgs(TestCase):
         self.assertFalse(page.has_previous)
 
 
-class TestForwardNullPagination(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        now = timezone.now()
-        cls.items = []
-        for i in range(2):  # index 0-1
-            author = Author.objects.create(name='Name %s' % i, age=i+20, created=now - datetime.timedelta(hours=i))
-            cls.items.append(author)
-        for i in range(5):  # index 2-6
-            author = Author.objects.create(name='NameNull %s' % (i + 2), age=None, created=now - datetime.timedelta(hours=i))
-            cls.items.append(author)
-        cls.paginator = CursorPaginator(Author.objects.all(), ('-age', '-created',))
-    # [1, 0, 2, 3, 4, 5, 6]
-    
-
-    def test_first_page(self):
-        page = self.paginator.page(first=3)
-        self.assertSequenceEqual(page, [self.items[1], self.items[0], self.items[2]])
-        self.assertTrue(page.has_next)
-        self.assertFalse(page.has_previous)
-
-    def test_second_page(self):
-        previous_page = self.paginator.page(first=3)
-        cursor = self.paginator.cursor(previous_page[-1])
-        page = self.paginator.page(first=2, after=cursor)
-        self.assertSequenceEqual(page, [self.items[3], self.items[4]])
-        self.assertTrue(page.has_next)
-        self.assertTrue(page.has_previous)
-
-    def test_last_page(self):
-        previous_page = self.paginator.page(first=5)
-        cursor = self.paginator.cursor(previous_page[-1])
-        page = self.paginator.page(first=10, after=cursor)
-        self.assertSequenceEqual(page, [self.items[5], self.items[6]])
-        self.assertFalse(page.has_next)
-        self.assertTrue(page.has_previous)
-
-
-class TestBackwardsNullPagination(TestCase):
-    @classmethod
-    def setUpTestData(cls):
-        now = timezone.now()
-        cls.items = []
-        for i in range(2):  # index 0-1
-            author = Author.objects.create(name='Name %s' % i, age=i+20, created=now - datetime.timedelta(hours=i))
-            cls.items.append(author)
-        for i in range(5):  # index 2-6
-            author = Author.objects.create(name='NameNull %s' % (i + 2), age=None, created=now - datetime.timedelta(hours=i))
-            cls.items.append(author)
-        cls.paginator = CursorPaginator(Author.objects.all(), ('-age', '-created',))
-
-    # [1, 0, 2, 3, 4, 5, 6]
-
-    def test_first_page(self):
-        page = self.paginator.page(last=2)
-        self.assertSequenceEqual(page, [self.items[5], self.items[6]])
-        self.assertTrue(page.has_previous)
-        self.assertFalse(page.has_next)
-
-    def test_second_page(self):
-        previous_page = self.paginator.page(last=2)
-        cursor = self.paginator.cursor(previous_page[0])
-        page = self.paginator.page(last=4, before=cursor)
-        self.assertSequenceEqual(page, [self.items[0], self.items[2], self.items[3], self.items[4]])
-        self.assertTrue(page.has_previous)
-        self.assertTrue(page.has_next)
-
-    def test_last_page(self):
-        previous_page = self.paginator.page(last=6)
-        cursor = self.paginator.cursor(previous_page[0])
-        page = self.paginator.page(last=10, before=cursor)
-        self.assertSequenceEqual(page, [self.items[1]])
-        self.assertFalse(page.has_previous)
-        self.assertTrue(page.has_next)
-
-
 class TestForwardPagination(TestCase):
 
     @classmethod
@@ -243,6 +167,118 @@ class TestRelationships(TestCase):
     def test_first_page(self):
         page = self.paginator.page(first=2)
         self.assertSequenceEqual(page, [self.items[1], self.items[3]])
+
+    def test_after_page(self):
+        cursor = self.paginator.cursor(self.items[17])
+        page = self.paginator.page(first=2, after=cursor)
+        self.assertSequenceEqual(page, [self.items[19], self.items[0]])
+
+
+class TestNoArgsWithNull(TestCase):
+    def test_with_items(self):
+        authors = [
+            Author.objects.create(name='Alice', age=30),
+            Author.objects.create(name='Bob', age=None),
+            Author.objects.create(name='Carol', age=None),
+            Author.objects.create(name='Dave', age=40)
+        ]
+        paginator = CursorPaginator(Author.objects.all(), ('-age', 'id',))
+        page = paginator.page()
+        self.assertSequenceEqual(page, [authors[3], authors[0], authors[1], authors[2]])
+        self.assertFalse(page.has_next)
+        self.assertFalse(page.has_previous)
+
+
+class TestForwardNullPagination(TestCase):
+    # When there are NULL values, there needs to be another key to make the sort unique as README Caveats say
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.items = []
+        for i in range(2):  # index 0-1
+            author = Author.objects.create(name='Name %s' % i, age=i+20, created=now - datetime.timedelta(hours=i))
+            cls.items.append(author)
+        for i in range(5):  # index 2-6
+            author = Author.objects.create(name='NameNull %s' % (i + 2), age=None, created=now - datetime.timedelta(hours=i))
+            cls.items.append(author)
+        cls.paginator = CursorPaginator(Author.objects.all(), ('-age', '-created',))
+    # [1, 0, 2, 3, 4, 5, 6]
+    
+
+    def test_first_page(self):
+        page = self.paginator.page(first=3)
+        self.assertSequenceEqual(page, [self.items[1], self.items[0], self.items[2]])
+        self.assertTrue(page.has_next)
+        self.assertFalse(page.has_previous)
+
+    def test_second_page(self):
+        previous_page = self.paginator.page(first=3)
+        cursor = self.paginator.cursor(previous_page[-1])
+        page = self.paginator.page(first=2, after=cursor)
+        self.assertSequenceEqual(page, [self.items[3], self.items[4]])
+        self.assertTrue(page.has_next)
+        self.assertTrue(page.has_previous)
+
+    def test_last_page(self):
+        previous_page = self.paginator.page(first=5)
+        cursor = self.paginator.cursor(previous_page[-1])
+        page = self.paginator.page(first=10, after=cursor)
+        self.assertSequenceEqual(page, [self.items[5], self.items[6]])
+        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_previous)
+
+
+class TestBackwardsNullPagination(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        now = timezone.now()
+        cls.items = []
+        for i in range(2):  # index 0-1
+            author = Author.objects.create(name='Name %s' % i, age=i+20, created=now - datetime.timedelta(hours=i))
+            cls.items.append(author)
+        for i in range(5):  # index 2-6
+            author = Author.objects.create(name='NameNull %s' % (i + 2), age=None, created=now - datetime.timedelta(hours=i))
+            cls.items.append(author)
+        cls.paginator = CursorPaginator(Author.objects.all(), ('-age', '-created',))
+        # => [1, 0, 2, 3, 4, 5, 6]
+
+    def test_first_page(self):
+        page = self.paginator.page(last=2)
+        self.assertSequenceEqual(page, [self.items[5], self.items[6]])
+        self.assertTrue(page.has_previous)
+        self.assertFalse(page.has_next)
+
+    def test_second_page(self):
+        previous_page = self.paginator.page(last=2)
+        cursor = self.paginator.cursor(previous_page[0])
+        page = self.paginator.page(last=4, before=cursor)
+        self.assertSequenceEqual(page, [self.items[0], self.items[2], self.items[3], self.items[4]])
+        self.assertTrue(page.has_previous)
+        self.assertTrue(page.has_next)
+
+    def test_last_page(self):
+        previous_page = self.paginator.page(last=6)
+        cursor = self.paginator.cursor(previous_page[0])
+        page = self.paginator.page(last=10, before=cursor)
+        self.assertSequenceEqual(page, [self.items[1]])
+        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_next)
+
+
+class TestRelationshipsWithNull(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.items = []
+        author_1 = Author.objects.create(name='Ana', age=25)  # odd number
+        author_2 = Author.objects.create(name='Bob')  # even number
+        for i in range(20):
+            post = Post.objects.create(name='Name %02d' % i, author=author_1 if i % 2 else author_2)
+            cls.items.append(post)
+        cls.paginator = CursorPaginator(Post.objects.all(), ('author__age', 'name'))
+
+    def test_first_page(self):
+        page = self.paginator.page(first=2)
+        self.assertSequenceEqual(page, [self.items[1], self.items[3]])  # Ana comes first
 
     def test_after_page(self):
         cursor = self.paginator.cursor(self.items[17])


### PR DESCRIPTION
Solves #44 

On a second thought, maybe it's easier to be able to see diffs than just the whole Gist file so I'm creating this PR as a draft for discussions 🙏 

TODO:
- [x] Add one or two more scenarios with NULLs to tests before making this ready for review.


[EDIT] Just for convenience, I'm copying some contents from #44


👋 First of all, thank you for this awesome library!
I encountered this None/Null issue at my workplace (modified) where the last object of the previous page has NULL value for one of the ordering keys.

ERROR:  invalid input syntax for type smallint: "None" at character 1564

... AND ("product"."tier" > 'None' OR ("product"."tier" = 'None' AND "product"."id" > '555'))) ORDER BY "product"."tier" ASC, "product"."id" DESC LIMIT 101

I made a patch and that is working for me but now I am trying to update this library, so I can use it as a regular library.

Whether Null comes at the beginning or at the end of the order is DB dependent. In that sense, my implementation there is a little bit opinionated for always putting NULL at the end (except when "last" exists). I personally cannot think of any reasons why NULL should come first but that can be configurable, too, if we like. (Caveat on README should be updated with this)