### PR TITLE
Support async queryset evaluation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8, 3.9, "3.10", "3.11"]
-        django-version: [4.0, 3.2]
+        django-version: [5.0, 4.2]
 
     services:
       postgres:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: ["3.10", "3.11"]
         django-version: [5.0, 4.2]
 
     services:

--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ def posts_api(request, after=None):
         'last_cursor': paginator.cursor(page[-1])
     }
     return data
+
+
+async def posts_api_async(request, after=None):
+    qs = Post.objects.all()
+    page_size = 10
+    paginator = CursorPaginator(qs, ordering=('-created', '-id'))
+    page = await paginator.apage(first=page_size, after=after)
+    data = {
+        'objects': [serialize_page(p) for p in page],
+        'has_next_page': page.has_next,
+        'last_cursor': paginator.cursor(page[-1])
+    }
+    return data
 ```
 
 Reverse pagination can be achieved by using the `last` and `before` arguments

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -36,9 +36,6 @@ class CursorPage(Sequence):
     def __repr__(self):
         return '<Page: [%s%s]>' % (', '.join(repr(i) for i in self.items[:21]), ' (remaining truncated)' if len(self.items) > 21 else '')
 
-    async def acount(self):
-        return await self.items.acount()
-
 
 class CursorPaginator(object):
     delimiter = '|'
@@ -75,10 +72,6 @@ class CursorPaginator(object):
         """
         Apply first/after, last/before filtering to the queryset
         """
-        page_size = first or last
-        if page_size is None:
-            return CursorPage(qs, self)
-
         from_last = last is not None
         if from_last and first is not None:
             raise ValueError('Cannot process first and last')
@@ -112,7 +105,7 @@ class CursorPaginator(object):
         qs = self._apply_paginator_arguments(qs, first, last, after, before)
 
         qs = list(qs)
-        page_size = first or last
+        page_size = first if first is not None else last
         items = qs[:page_size]
         if last is not None:
             items.reverse()
@@ -124,7 +117,7 @@ class CursorPaginator(object):
         qs = self.queryset
         qs = self._apply_paginator_arguments(qs, first, last, after, before)
 
-        page_size = first or last
+        page_size = first if first is not None else last
         items = []
         async for item in qs[:page_size].aiterator():
             items.append(item)

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -108,6 +108,7 @@ class CursorPaginator(object):
         self._apply_paginator_arguments(qs, first, last, after, before)
 
         qs = list(qs)
+        page_size = first or last
         items = qs[:page_size]
         if last is not None:
             items.reverse()
@@ -119,6 +120,7 @@ class CursorPaginator(object):
         qs = self.queryset
         self._apply_paginator_arguments(qs, first, last, after, before)
 
+        page_size = first or last
         items = await sync_to_async(list)(qs[:page_size])
         if last is not None:
             items.reverse()

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -1,4 +1,3 @@
-from asgiref.sync import sync_to_async
 from base64 import b64decode, b64encode
 from collections.abc import Sequence
 
@@ -121,7 +120,9 @@ class CursorPaginator(object):
         self._apply_paginator_arguments(qs, first, last, after, before)
 
         page_size = first or last
-        items = await sync_to_async(list)(qs[:page_size])
+        items = []
+        async for item in qs[:page_size]:
+            items.append(item)
         if last is not None:
             items.reverse()
         has_additional = (await qs.acount()) > len(items)

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -121,7 +121,7 @@ class CursorPaginator(object):
 
         page_size = first or last
         items = []
-        async for item in qs[:page_size]:
+        async for item in qs[:page_size].aiterator():
             items.append(item)
         if last is not None:
             items.reverse()

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -89,6 +89,8 @@ class CursorPaginator(object):
         if last is not None:
             qs = qs.order_by(*self._nulls_ordering(reverse_ordering(self.ordering), from_last=True))[:last + 1]
 
+        return qs
+
     def _get_cursor_page(self, items, has_additional, first, last, after, before):
         """
         Create and return the cursor page for the given items
@@ -104,7 +106,7 @@ class CursorPaginator(object):
 
     def page(self, first=None, last=None, after=None, before=None):
         qs = self.queryset
-        self._apply_paginator_arguments(qs, first, last, after, before)
+        qs = self._apply_paginator_arguments(qs, first, last, after, before)
 
         qs = list(qs)
         page_size = first or last
@@ -117,7 +119,7 @@ class CursorPaginator(object):
 
     async def apage(self, first=None, last=None, after=None, before=None):
         qs = self.queryset
-        self._apply_paginator_arguments(qs, first, last, after, before)
+        qs = self._apply_paginator_arguments(qs, first, last, after, before)
 
         page_size = first or last
         items = []

--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -36,6 +36,9 @@ class CursorPage(Sequence):
     def __repr__(self):
         return '<Page: [%s%s]>' % (', '.join(repr(i) for i in self.items[:21]), ' (remaining truncated)' if len(self.items) > 21 else '')
 
+    async def acount(self):
+        return await self.items.acount()
+
 
 class CursorPaginator(object):
     delimiter = '|'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,11 +18,27 @@ class TestNoArgs(TestCase):
         self.assertFalse(page.has_next)
         self.assertFalse(page.has_previous)
 
+    async def test_async_empty(self):
+        paginator = CursorPaginator(Post.objects.all(), ('id',))
+        page = await paginator.apage()
+        self.assertEqual(len(page), 0)
+        self.assertFalse(page.has_next)
+        self.assertFalse(page.has_previous)
+
     def test_with_items(self):
         for i in range(20):
             Post.objects.create(name='Name %s' % i)
         paginator = CursorPaginator(Post.objects.all(), ('id',))
         page = paginator.page()
+        self.assertEqual(len(page), 20)
+        self.assertFalse(page.has_next)
+        self.assertFalse(page.has_previous)
+
+    async def test_async_with_items(self):
+        for i in range(20):
+            await Post.objects.acreate(name='Name %s' % i)
+        paginator = CursorPaginator(Post.objects.all(), ('id',))
+        page = await paginator.apage()
         self.assertEqual(len(page), 20)
         self.assertFalse(page.has_next)
         self.assertFalse(page.has_previous)
@@ -41,6 +57,12 @@ class TestForwardPagination(TestCase):
 
     def test_first_page(self):
         page = self.paginator.page(first=2)
+        self.assertSequenceEqual(page, [self.items[0], self.items[1]])
+        self.assertTrue(page.has_next)
+        self.assertFalse(page.has_previous)
+
+    async def test_async_first_page(self):
+        page = await self.paginator.apage(first=2)
         self.assertSequenceEqual(page, [self.items[0], self.items[1]])
         self.assertTrue(page.has_next)
         self.assertFalse(page.has_previous)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -55,6 +55,18 @@ class TestForwardPagination(TestCase):
             cls.items.append(post)
         cls.paginator = CursorPaginator(Post.objects.all(), ('-created',))
 
+    def test_first_page_zero(self):
+        page = self.paginator.page(first=0)
+        self.assertSequenceEqual(page, [])
+        self.assertTrue(page.has_next)
+        self.assertFalse(page.has_previous)
+
+    async def test_async_first_page_zero(self):
+        page = await self.paginator.apage(first=0)
+        self.assertSequenceEqual(page, [])
+        self.assertTrue(page.has_next)
+        self.assertFalse(page.has_previous)
+
     def test_first_page(self):
         page = self.paginator.page(first=2)
         self.assertSequenceEqual(page, [self.items[0], self.items[1]])
@@ -126,6 +138,18 @@ class TestBackwardsPagination(TestCase):
             post = Post.objects.create(name='Name %s' % i, created=now - datetime.timedelta(hours=i))
             cls.items.append(post)
         cls.paginator = CursorPaginator(Post.objects.all(), ('-created',))
+
+    def test_first_page_zero(self):
+        page = self.paginator.page(last=0)
+        self.assertSequenceEqual(page, [])
+        self.assertTrue(page.has_previous)
+        self.assertFalse(page.has_next)
+
+    async def test_async_first_page_zero(self):
+        page = await self.paginator.apage(last=0)
+        self.assertSequenceEqual(page, [])
+        self.assertTrue(page.has_previous)
+        self.assertFalse(page.has_next)
 
     def test_first_page(self):
         page = self.paginator.page(last=2)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -75,6 +75,14 @@ class TestForwardPagination(TestCase):
         self.assertTrue(page.has_next)
         self.assertTrue(page.has_previous)
 
+    async def test_async_second_page(self):
+        previous_page = await self.paginator.apage(first=2)
+        cursor = self.paginator.cursor(previous_page[-1])
+        page = await self.paginator.apage(first=2, after=cursor)
+        self.assertSequenceEqual(page, [self.items[2], self.items[3]])
+        self.assertTrue(page.has_next)
+        self.assertTrue(page.has_previous)
+
     def test_last_page(self):
         previous_page = self.paginator.page(first=18)
         cursor = self.paginator.cursor(previous_page[-1])
@@ -83,10 +91,26 @@ class TestForwardPagination(TestCase):
         self.assertFalse(page.has_next)
         self.assertTrue(page.has_previous)
 
+    async def test_async_last_page(self):
+        previous_page = await self.paginator.apage(first=18)
+        cursor = self.paginator.cursor(previous_page[-1])
+        page = await self.paginator.apage(first=2, after=cursor)
+        self.assertSequenceEqual(page, [self.items[18], self.items[19]])
+        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_previous)
+
     def test_incomplete_last_page(self):
         previous_page = self.paginator.page(first=18)
         cursor = self.paginator.cursor(previous_page[-1])
         page = self.paginator.page(first=100, after=cursor)
+        self.assertSequenceEqual(page, [self.items[18], self.items[19]])
+        self.assertFalse(page.has_next)
+        self.assertTrue(page.has_previous)
+
+    async def test_async_incomplete_last_page(self):
+        previous_page = await self.paginator.apage(first=18)
+        cursor = self.paginator.cursor(previous_page[-1])
+        page = await self.paginator.apage(first=100, after=cursor)
         self.assertSequenceEqual(page, [self.items[18], self.items[19]])
         self.assertFalse(page.has_next)
         self.assertTrue(page.has_previous)
@@ -109,10 +133,24 @@ class TestBackwardsPagination(TestCase):
         self.assertTrue(page.has_previous)
         self.assertFalse(page.has_next)
 
+    async def test_async_first_page(self):
+        page = await self.paginator.apage(last=2)
+        self.assertSequenceEqual(page, [self.items[18], self.items[19]])
+        self.assertTrue(page.has_previous)
+        self.assertFalse(page.has_next)
+
     def test_second_page(self):
         previous_page = self.paginator.page(last=2)
         cursor = self.paginator.cursor(previous_page[0])
         page = self.paginator.page(last=2, before=cursor)
+        self.assertSequenceEqual(page, [self.items[16], self.items[17]])
+        self.assertTrue(page.has_previous)
+        self.assertTrue(page.has_next)
+
+    async def test_async_second_page(self):
+        previous_page = await self.paginator.apage(last=2)
+        cursor = self.paginator.cursor(previous_page[0])
+        page = await self.paginator.apage(last=2, before=cursor)
         self.assertSequenceEqual(page, [self.items[16], self.items[17]])
         self.assertTrue(page.has_previous)
         self.assertTrue(page.has_next)
@@ -125,10 +163,26 @@ class TestBackwardsPagination(TestCase):
         self.assertFalse(page.has_previous)
         self.assertTrue(page.has_next)
 
+    async def test_async_last_page(self):
+        previous_page = await self.paginator.apage(last=18)
+        cursor = self.paginator.cursor(previous_page[0])
+        page = await self.paginator.apage(last=2, before=cursor)
+        self.assertSequenceEqual(page, [self.items[0], self.items[1]])
+        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_next)
+
     def test_incomplete_last_page(self):
         previous_page = self.paginator.page(last=18)
         cursor = self.paginator.cursor(previous_page[0])
         page = self.paginator.page(last=100, before=cursor)
+        self.assertSequenceEqual(page, [self.items[0], self.items[1]])
+        self.assertFalse(page.has_previous)
+        self.assertTrue(page.has_next)
+
+    async def test_async_incomplete_last_page(self):
+        previous_page = await self.paginator.apage(last=18)
+        cursor = self.paginator.cursor(previous_page[0])
+        page = await self.paginator.apage(last=100, before=cursor)
         self.assertSequenceEqual(page, [self.items[0], self.items[1]])
         self.assertFalse(page.has_previous)
         self.assertTrue(page.has_next)


### PR DESCRIPTION
Closes #50 

Was switching our codebase over to async so we could use dataloaders and realized this library didn't support async querysets

I cannot claim to be very knowledgeable about async python but this is what I did locally :shrug: