### PR TITLE
Remove obsolete `acount()` during `apage()` evaluation

### DIFF
--- a/cursor_pagination.py
+++ b/cursor_pagination.py
@@ -119,11 +119,12 @@ class CursorPaginator(object):
 
         page_size = first if first is not None else last
         items = []
-        async for item in qs[:page_size].aiterator():
+        async for item in qs.aiterator():
             items.append(item)
+        has_additional = False if page_size is None else len(items) > page_size
+        items = items[:page_size]
         if last is not None:
             items.reverse()
-        has_additional = (await qs.acount()) > len(items)
 
         return self._get_cursor_page(items, has_additional, first, last, after, before)
 


### PR DESCRIPTION
The previous implementation performed two database queries to evaluate `apage()`. 
Now we make use of the pre-fetched element that is prepared in `_apply_paginator_arguments` 
to check if there are additional pages without using `acount()`.

Added tests for `page()` and `apage()` to verify only one database query is performed.
Tested against py3.13.2 / django 5.2.8

See #54 for full discussion.
